### PR TITLE
Clean up unnecessary YAML metadata from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
----
-aliases: []
-date_created: 2025-03-22 15:03
-date_modified: 2025-07-12 19:07
-tags: []
-title: Curate, Cultivate, Connect Knowledge System
----
-
 # Curate, Cultivate, Connect Knowledge System
 
 _Note: This repository is undergoing a significant overhaul as the author has continued refining the system. Contact jason.gilbertson@gmail.com if you'd like to learn more about an in-progress book on this vault and methodology._


### PR DESCRIPTION
## Summary
- Remove Obsidian-specific YAML frontmatter from README.md
- Keep README focused on repository documentation rather than Obsidian metadata

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm no essential information was removed

🤖 Generated with [Claude Code](https://claude.ai/code)