### PR TITLE
Add optional Reference: section to atomic-note templates and notes

### DIFF
--- a/Atomic Notes/202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea.md
+++ b/Atomic Notes/202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea.md
@@ -16,6 +16,10 @@ Think of atomic notes as LEGO bricks. Each brick is a simple, independent unit, 
 
 For example, instead of a long note titled "Photosynthesis," you would create separate atomic notes for "Chlorophyll's Role in Light Absorption," "The Calvin Cycle," and "Inputs and Outputs of Photosynthesis." Each note stands alone but can be linked to the others.
 
+Reference:
+
+- Related concepts: [[202508311127 The principle of atomicity is the practice of breaking information into small, self-contained units, with each unit focused on a single, complete idea|Principle of Atomicity]] and [[202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes|Zettelkasten]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-08-31]]

--- a/Atomic Notes/202508311127 The principle of atomicity is the practice of breaking information into small, self-contained units, with each unit focused on a single, complete idea.md
+++ b/Atomic Notes/202508311127 The principle of atomicity is the practice of breaking information into small, self-contained units, with each unit focused on a single, complete idea.md
@@ -16,6 +16,10 @@ This principle is like organizing a kitchen pantry. Instead of keeping a large, 
 
 For example, instead of writing one long note about the American Revolution, an atomic approach would create separate notes for "The Stamp Act of 1765," "The Boston Tea Party," and "The role of mercantilism in colonial unrest," each fully explaining its specific topic.
 
+Reference:
+
+- Related concepts: [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|Atomic Note]] and [[202508311132 Modularity is a software design principle that involves dividing a program into separate, independent modules, where each module is responsible for a specific piece of the program's functionality|Modularity]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-08-31]]

--- a/Atomic Notes/202508311132 Modularity is a software design principle that involves dividing a program into separate, independent modules, where each module is responsible for a specific piece of the program's functionality.md
+++ b/Atomic Notes/202508311132 Modularity is a software design principle that involves dividing a program into separate, independent modules, where each module is responsible for a specific piece of the program's functionality.md
@@ -17,6 +17,10 @@ Think of a car's construction. A car is not built as a single, monolithic piece 
 
 For example, a large e-commerce website is built modularly. One module might handle user authentication (login, registration), another manages the product catalog, a third processes payments, and a fourth handles shipping. Each can be updated or replaced without rebuilding the entire website.
 
+Reference:
+
+- Related concepts: [[202511181119 Abstraction is the process of identifying and isolating the essential features of a concept or object while deliberately ignoring irrelevant details|Abstraction]] and [[202508311142 A graph is a non-linear data structure composed of a set of vertices (or nodes) and a set of edges that represent connections between these vertices|Graph Data Structure]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-08-31]]

--- a/Atomic Notes/202508311142 A graph is a non-linear data structure composed of a set of vertices (or nodes) and a set of edges that represent connections between these vertices.md
+++ b/Atomic Notes/202508311142 A graph is a non-linear data structure composed of a set of vertices (or nodes) and a set of edges that represent connections between these vertices.md
@@ -18,6 +18,10 @@ Think of a graph as a city map. Each intersection or landmark is a vertex, and t
 
 For example, on a social media platform, each user profile is a vertex, and a "friendship" or "follow" connection between two users is an edge. This graph structure allows the platform to suggest mutual friends and analyze the social network's connections.
 
+Reference:
+
+- Related concepts: [[202508311132 Modularity is a software design principle that involves dividing a program into separate, independent modules, where each module is responsible for a specific piece of the program's functionality|Modularity]] and [[202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes|Zettelkasten]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-08-31]]

--- a/Atomic Notes/202509010952 Spaced repetition is a learning technique that involves reviewing information at increasing intervals to improve long-term retention.md
+++ b/Atomic Notes/202509010952 Spaced repetition is a learning technique that involves reviewing information at increasing intervals to improve long-term retention.md
@@ -17,6 +17,10 @@ This technique is like a gardener watering a plant. Rather than flooding the pla
 
 For example, when learning Spanish vocabulary, you might review the word "gato" (cat) after one day, then three days, then one week, and then two weeks. Each successful recall pushes the next review further into the future, expanding the interval as the word becomes more firmly embedded in memory.
 
+Reference:
+
+- Related concepts: [[202509010956 The Ebbinghaus forgetting curve is a model showing how memory retention declines exponentially over time if there is no attempt to review the learned information|Ebbinghaus Forgetting Curve]] and [[202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes|Zettelkasten]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-09-01]]

--- a/Atomic Notes/202509010956 The Ebbinghaus forgetting curve is a model showing how memory retention declines exponentially over time if there is no attempt to review the learned information.md
+++ b/Atomic Notes/202509010956 The Ebbinghaus forgetting curve is a model showing how memory retention declines exponentially over time if there is no attempt to review the learned information.md
@@ -22,7 +22,7 @@ For example, after studying a list of new vocabulary words, a person might recal
 Reference:
 
 - Related concept: [[202509010952 Spaced repetition is a learning technique that involves reviewing information at increasing intervals to improve long-term retention|Spaced Repetition]].
-![[20240905205858 Ebbinghaus forgetting curve.png]]
+- ![[20240905205858 Ebbinghaus forgetting curve.png]]
 
 Sources:
 

--- a/Atomic Notes/202509010956 The Ebbinghaus forgetting curve is a model showing how memory retention declines exponentially over time if there is no attempt to review the learned information.md
+++ b/Atomic Notes/202509010956 The Ebbinghaus forgetting curve is a model showing how memory retention declines exponentially over time if there is no attempt to review the learned information.md
@@ -19,6 +19,9 @@ This process is like a hot cup of coffee cooling down. It loses heat rapidly at 
 
 For example, after studying a list of new vocabulary words, a person might recall 100% immediately, but only 60% after 20 minutes, 45% after an hour, and just 20% after a month if they do not review the material at all.
 
+Reference:
+
+- Related concept: [[202509010952 Spaced repetition is a learning technique that involves reviewing information at increasing intervals to improve long-term retention|Spaced Repetition]].
 ![[20240905205858 Ebbinghaus forgetting curve.png]]
 
 Sources:

--- a/Atomic Notes/202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes.md
+++ b/Atomic Notes/202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes.md
@@ -18,6 +18,10 @@ Think of it as a personal, internal version of Wikipedia. Each note is like a si
 
 For example, a researcher studying productivity might create a note on the "Pomodoro Technique" and link it to other notes on "Time Blocking," "Deep Work," and "Cognitive Load Theory," building a web of related concepts rather than storing them in separate, unrelated documents.
 
+Reference:
+
+- Related concepts: [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|Atomic Note]] and [[202509011019 A structure note serves as a curated entry point or an organized overview of a specific topic or line of thought within a note network|Structure Note]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-09-01]]

--- a/Atomic Notes/202509011019 A structure note serves as a curated entry point or an organized overview of a specific topic or line of thought within a note network.md
+++ b/Atomic Notes/202509011019 A structure note serves as a curated entry point or an organized overview of a specific topic or line of thought within a note network.md
@@ -16,6 +16,10 @@ Think of a structure note as the table of contents for a specific topic within y
 
 For example, a student might create a "Stoicism" structure note that contains an ordered list of links to their [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|atomic notes]] on "The [[202504231231 The Stoic dichotomy of control divides reality into things we can control—our judgments, desires, and actions—and things we cannot, such as external events, other people, and outcomes|Dichotomy of Control]]," "Amor Fati," and "Premeditatio Malorum," providing a clear learning path through the philosophy.
 
+Reference:
+
+- Related concepts: [[202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes|Zettelkasten]] and [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|Atomic Note]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-09-01]]

--- a/Atomic Notes/202509030621 A reference note captures key ideas from an external source, serving as a bridge between consuming information and creating original thought.md
+++ b/Atomic Notes/202509030621 A reference note captures key ideas from an external source, serving as a bridge between consuming information and creating original thought.md
@@ -18,6 +18,10 @@ Think of it as a field journalist's notebook. For some information, the journali
 
 For example, after reading a scientific paper, you might create a reference note that summarizes the study's methodology in your own words but also includes a direct quote of the paper's central hypothesis to capture its exact wording for future citation.
 
+Reference:
+
+- Related concepts: [[202509011019 A structure note serves as a curated entry point or an organized overview of a specific topic or line of thought within a note network|Structure Note]] and [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|Atomic Note]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-09-03]]

--- a/Atomic Notes/202509030636 The DAE framework is a structured method for writing atomic notes that ensures clarity and retention by organizing each note into three parts—a concise Definition, a relatable Analogy, and a concrete Example.md
+++ b/Atomic Notes/202509030636 The DAE framework is a structured method for writing atomic notes that ensures clarity and retention by organizing each note into three parts—a concise Definition, a relatable Analogy, and a concrete Example.md
@@ -16,6 +16,10 @@ The DAE framework is like a three-legged stool for knowledge. The Definition is 
 
 For example, when creating a note about "cognitive dissonance," you would first define it in your own words, then create an analogy (like holding two opposing magnets), and finally provide a real-world example (like a smoker who knows smoking is unhealthy).
 
+Reference:
+
+- Related concepts: [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|Atomic Note]] and [[202509030651 The 5W framework is a system that uses five quality-gate questions to decide whether to engage with a piece of information|5W Framework]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-09-03]]

--- a/Atomic Notes/202509030651 The 5W framework is a system that uses five quality-gate questions to decide whether to engage with a piece of information.md
+++ b/Atomic Notes/202509030651 The 5W framework is a system that uses five quality-gate questions to decide whether to engage with a piece of information.md
@@ -22,6 +22,10 @@ Think of the 5W framework as a bouncer at an exclusive club for your mind. Befor
 
 For example, before saving an article about a new programming language, you would ask: "What for?" (to use on a specific project), "Why now?" (the project starts next week), "What else?" (I'm not reading the documentation for my current language), "Who from?" (an industry-leading expert), and "Where to?" (it connects to my [[202508311058 An atomic note is a self-contained unit of knowledge that captures a single, complete idea|atomic notes]] on software development).
 
+Reference:
+
+- Related concepts: [[202509030636 The DAE framework is a structured method for writing atomic notes that ensures clarity and retention by organizing each note into three parts—a concise Definition, a relatable Analogy, and a concrete Example|DAE Framework]] and [[202509030621 A reference note captures key ideas from an external source, serving as a bridge between consuming information and creating original thought|Reference Note]].
+
 Sources:
 
 1. Gemini 2.5 last accessed [[2025-09-03]]

--- a/Atomic Notes/202511181119 Abstraction is the process of identifying and isolating the essential features of a concept or object while deliberately ignoring irrelevant details.md
+++ b/Atomic Notes/202511181119 Abstraction is the process of identifying and isolating the essential features of a concept or object while deliberately ignoring irrelevant details.md
@@ -15,6 +15,10 @@ Think of abstraction like using a subway map. The map doesn't show every buildin
 
 For example, when a programmer creates a "User" class in software, they abstract the concept of a user by including only relevant attributes like username and email, while ignoring countless real-world details like hair color, favorite food, or shoe size. This abstraction makes the code manageable and focused on what the application actually needs.
 
+Reference:
+
+- Related concepts: [[202508311132 Modularity is a software design principle that involves dividing a program into separate, independent modules, where each module is responsible for a specific piece of the program's functionality|Modularity]] and [[202508311142 A graph is a non-linear data structure composed of a set of vertices (or nodes) and a set of edges that represent connections between these vertices|Graph Data Structure]].
+
 Sources:
 
 1. Claude Sonnet 4.5 last accessed [[2025-11-18]]

--- a/Atomic Notes/202511181121 Pattern recognition is the cognitive ability to identify recurring structures, regularities, or relationships across different instances of data or experiences.md
+++ b/Atomic Notes/202511181121 Pattern recognition is the cognitive ability to identify recurring structures, regularities, or relationships across different instances of data or experiences.md
@@ -17,6 +17,10 @@ Think of pattern recognition like a musician hearing a chord progression. Even i
 
 For example, a doctor recognizes patterns when diagnosing illness—they notice that fever, cough, and fatigue together suggest influenza because they've seen this combination repeatedly in past patients. This pattern recognition allows them to make accurate diagnoses quickly without needing to investigate every possible illness from scratch each time.
 
+Reference:
+
+- Related concepts: [[202509011003 The Zettelkasten method is a knowledge management system that organizes information into a network of interconnected, atomic notes|Zettelkasten]] and [[202511181119 Abstraction is the process of identifying and isolating the essential features of a concept or object while deliberately ignoring irrelevant details|Abstraction]].
+
 Sources:
 
 1. Claude Sonnet 4.5 last accessed [[2025-11-18]]

--- a/Templates/Atomic Note Template (Anki).md
+++ b/Templates/Atomic Note Template (Anki).md
@@ -24,6 +24,10 @@ For example, [EXAMPLE: Concrete application]
 
 END
 
+Reference:
+
+- [[Link to a related note]]
+
 Sources:
 
 1. x

--- a/Templates/Atomic Note Template (Default).md
+++ b/Templates/Atomic Note Template (Default).md
@@ -14,6 +14,10 @@ title: Title
 
 For example, [EXAMPLE: Concrete application]
 
+Reference:
+
+- [[Link to a related note]]
+
 Sources:
 
 1. [x]


### PR DESCRIPTION
Part 3 of 3 for jrgilbertson/networked-thinking-book#239 (companion vault).

## What this does
Additive only — introduces the optional `Reference:` section (singular label, bulleted: related-note links + figures) above the existing numbered `Sources:` section.

- **Both atomic-note templates** (Default + Anki) gain a `Reference:` placeholder above `Sources:`.
- **13 of 14 example notes** gain a `Reference:` section linking genuinely related notes (sourced from the structure-note groupings — no fabricated links). "Dichotomy of Control" has no related note and is intentionally left DAE + `Sources:` only, demonstrating that `Reference:` is optional.
- The Ebbinghaus note's figure is moved from the DAE body into its `Reference:` section.

## Evidence
- Every `[[wikilink]]` target resolves to a real note (em-dashes byte-matched).
- Audited with the (Reference:-aware) skills auditor: base-vs-head finding-sets are **identical** — zero new findings introduced.
- 15 files changed (2 templates + 13 notes); `Sources:` untouched everywhere.

## Note
Pre-existing uncommitted working-tree changes (`Prompts/atomic-note-generator.md`, `Templates/Daily Note Template.md`, `.obsidian/workspace.json`) were deliberately left untouched and are NOT part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)