### PR TITLE
docs: rebuild README for book launch, add changelog and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [1.1.0] - 2025-11-19
+## [1.1.0] - 2025-11-18
 
 ### Changed
 
@@ -14,7 +14,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated documentation for the GitHub template and Releases distribution paths.
 - Adjusted graph view scaling and Obsidian workspace file references.
 
-## [1.0.0] - 2025-11-18
+## [1.0.0] - 2025-11-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this vault are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [1.1.0] - 2025-11-19
+
+### Changed
+
+- Updated documentation for accuracy and expanded vault content.
+- Updated documentation for the GitHub template and Releases distribution paths.
+- Adjusted graph view scaling and Obsidian workspace file references.
+
+## [1.0.0] - 2025-11-18
+
+### Added
+
+- Comprehensive folder structure for the knowledge system.
+- Claude Code GitHub Actions workflow.
+- Comprehensive atomic notes and an interactive getting-started guide.
+
+### Changed
+
+- Replaced the MIT License with Creative Commons Attribution 4.0.
+- Cleaned up unnecessary YAML metadata from the README.
+- Replaced wiki-style links with plain text for GitHub rendering.
+- Updated vault documentation, templates, and structure for the book launch.
+
+[1.1.0]: https://github.com/jrgilbertson/networked-thinking/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/jrgilbertson/networked-thinking/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,120 +1,45 @@
 # Networked Thinking
 
-The official companion vault for "Networked Thinking" (launching 2026). It's a complete, working implementation of the methodology with examples of every component you'll read about in the book.
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](LICENSE.md)
+[![Latest release](https://img.shields.io/github/v/release/jrgilbertson/networked-thinking)](https://github.com/jrgilbertson/networked-thinking/releases)
 
-Want to be notified when the book launches? [Join our email list here](https://www.networkedthinking.ai).
+Networked Thinking is a book and practical system for turning saved articles, highlights, and notes into usable context for writing, decisions, and work. This vault is the system's working implementation, built to accompany the book.
 
-## Why This System?
+## Purpose
 
-### The Problem with Traditional Knowledge Management
+I built the original setup in 2022 after realizing I confused saving information with learning from it. AI has made that mistake easier to make. The system protects the useful friction of writing down what I know, what connects, and what I still need to figure out. Then when I bring in AI, I'm asking it to work with my thinking instead of replacing it.
 
-Most knowledge management systems fail because they optimize for collecting rather than understanding. Tags proliferate into chaos. Folders force artificial hierarchies on networked information. You save everything but understand nothing. Even sophisticated systems like Zettelkasten need adaptation for our digital, AI-enhanced world.
+This vault is the working implementation. Every note type, template, and folder described in the forthcoming book "Networked Thinking" by Jason Gilbertson and Terri Yeh is built out and linked, so you can see the system running rather than read about it in the abstract. Curate what earns a place using the 5W framework. Connect ideas through links and structure notes instead of folder hierarchies. Cultivate the system through regular review so it gets more useful with use.
 
-### The Networked Thinking Solution
+This is one way to run the methodology, not the only way. Adapt it to how you already think.
 
-This methodology addresses these fundamental issues through three core practices:
+## Quickstart
 
-1. **Curate**: Practice selective capture based on clear criteria. Not everything deserves to be saved. Our 5W framework (What for? Why now? What else? Who from? Where to?) ensures each piece of information earns its place through genuine utility.
-2. **Connect**: Build explicit relationships between ideas using aliases, backlinks, and structure notes. Knowledge forms networks, not hierarchies. Multiple pathways to the same concept mirror how memory works and how AI processes information.
-3. **Cultivate**: Maintain a living system through consistent practices. Notes evolve as understanding deepens. Connections strengthen through use. The system becomes more valuable over time through active tending.
+Install [Obsidian](https://obsidian.md/), the free local-first app this vault is built for. Then either click "Use this template" on this repository to create your own version-controlled copy, or download the latest release ZIP from the [Releases page](https://github.com/jrgilbertson/networked-thinking/releases) for a plain folder. Open that folder as a vault in Obsidian (File → Open Vault), then read [GETTING-STARTED.md](GETTING-STARTED.md) for the full folder map, template inventory, and linking mechanics.
 
-## What's Included
+## Structure
 
-This vault contains working examples of every component described in the "Networked Thinking" book. You can examine how each piece works, use them as templates, and adapt them to your needs.
+Content is organized by workflow state, not topic category. Links and structure notes carry the topic organization instead of folders. The essential folders:
 
-### Complete and Ready to Use
-
-- **14 Atomic Notes**: Demonstrating single-concept clarity with the DAE framework (Definition-Analogy-Example)
-- **3 Structure Notes**: Showing how to organize and navigate knowledge networks
-    - Networked Thinking System (main methodology hub)
-    - Thinking and Learning (cognitive tools and memory)
-    - System Design (architecture principles)
-- **14 Templates**: For consistent note creation across all types
-    - Atomic Note (with optional Anki block)
-    - Daily Note, Weekly Review, Quarterly Review, Meeting Note
-    - Decision, Reference Note, Structure Note, Person Note
-    - Vocabulary, General Note
-    - Company, Content, Writing Draft
-- **1 Reference Note**: "How to Take Smart Notes" fully processed and linked
-- **AI prompts (dual-track)**: The book's ready-to-use atomic-note prompt lives in Appendix D—paste it into any chat AI. For agentic assistants working directly in your vault, the open-source [Networked Thinking Skills](https://github.com/jrgilbertson/networked-thinking-skills) project adds `atomic-note` and `atomic-note-audit` skills (`npx skills add`). Collect your own prompts in the `Prompts/` folder.
-- **Core Folder Structure**: Organized for both human navigation and AI compatibility
-- **Workflow Examples**: Sample daily notes (5), weekly reviews, and meeting notes demonstrating capture and reflection practices
-- **Sample Person Notes**: 3 person profile examples (Carl Sagan, Grace Hopper, and a "Your Name" starter)
-
-### Coming Soon
-
-- **Additional Vocabulary Entries**: Language learning and pronunciation examples
-- **Advanced Techniques**: Cross-domain linking, emergence patterns
-
-## Five Principles for Human-AI Collaboration
-
-1. **Atomic thinking with consistent structure**: One idea per note with internal organization supporting both human understanding and machine parsing
-2. **Selective curation using explicit criteria**: Information must be worth your future self's time
-3. **Explicit connections through aliases and links**: Relationships between ideas must be visible and navigable
-4. **Natural language for broad accessibility**: Clear writing that humans understand is what AI systems can process
-5. **Evolution through active maintenance**: Notes should reflect growing understanding, not remain static
-
-## Getting Started
-
-1. **Install [Obsidian](https://obsidian.md/)**: Download the free, local-first knowledge management app.
-2. **Get the vault** (choose one option):
-	- **Option A: Use GitHub Template** (recommended if you want version control)
-		1. Click the green "Use this template" button at the top of the [GitHub repository](https://github.com/jrgilbertson/networked-thinking)
-		2. Create your own repository from this template
-		3. Clone your new repository to your local machine
-		4. Benefits: Full git history, easy updates, your own version control
-	- **Option B: Download from Releases**
-		1. Visit the [Releases section](https://github.com/jrgilbertson/networked-thinking/releases)
-		2. Download the latest release ZIP file
-		3. Extract to your desired location
-		4. Benefits: Simple file access, no git required, just download and go
-3. **Open the folder as a vault in Obsidian**: Select File → Open Vault → Choose the networked-thinking folder.
-4. **Read [GETTING-STARTED.md](GETTING-STARTED.md)**: Overview of the vault structure, folders, templates, and linking mechanics.
-
-## Vault Structure
-
-```markdown
-networked-thinking/
-├── Atomic Notes/          # Single-concept notes (YYYYMMDDHHMM format)
-├── Structure Notes/       # Topic maps and navigation hubs
-├── Reference Notes/       # Literature notes from external sources
-├── Templates/            # Consistent starting points
-├── Inbox/               # Capture before curation
-├── Reviews/             # Daily, weekly, quarterly reflections
-├── Projects/            # Active project documentation
-├── People/              # Individual profiles and connections
-├── Meetings/            # Meeting notes and decisions
-├── Places and Things/   # Location and object references (optional)
-├── Vocabulary Notes/    # Language learning and pronunciation (optional)
-├── Prompts/             # AI workflows for recurring tasks
-└── Attachments/         # Images and supporting files
+```text
+Atomic Notes/     Single-concept notes, one idea each (YYYYMMDDHHMM filenames)
+Structure Notes/  Topic maps that link related atomic notes together
+Reference Notes/  Notes on external sources, kept before they're synthesized
+Templates/        Starting points for every note type
+Inbox/            Raw capture, sorted during weekly review
+Reviews/          Daily, weekly, and quarterly reflection notes
 ```
 
-## Key Features
+People, Meetings, Projects, Vocabulary Notes, and Places and Things are optional workflow folders, added only when a real need shows up. [GETTING-STARTED.md](GETTING-STARTED.md) has the complete folder map, the full template inventory, and the wikilink/alias mechanics that hold the network together.
 
-- **Timestamp-based naming**: Every atomic note uses YYYYMMDDHHMM format to ensure uniqueness and chronological ordering.
-- **Consistent note structure**: Templates provide reliable starting points for processing information across all note types.
-- **Multiple navigation paths**: Find information through aliases, tags, backlinks, and structure notes instead of rigid hierarchies.
-- **Minimal plugin dependencies**: The system works with core Obsidian features for long-term sustainability and portability.
-- **Git-friendly plain text**: All notes are markdown files that work seamlessly with version control and collaboration tools.
-- **AI-compatible structure**: Consistent formatting and explicit connections enable AI tools to navigate and enhance your knowledge system.
+For agentic assistants working directly in the vault, the companion [Networked Thinking Skills](https://github.com/jrgilbertson/networked-thinking-skills) project adds `atomic-note` and `atomic-note-audit` skills (`npx skills add`). The book's paste-into-any-chat-AI prompt lives in Appendix D.
 
-## Philosophy
+## Status
 
-This system works because it aligns with cognitive science research on how humans process and retain information. When you write in your own words, create explicit connections, and regularly review and refine, you engage the mechanisms that create lasting understanding.
+This vault is active, pre-launch material for the book, due in 2026. It already holds fourteen atomic notes, three structure notes, fourteen templates, five days of example daily notes, and one fully processed reference note, all real content to open and read rather than stub files. Two tagged releases exist so far. See [CHANGELOG.md](CHANGELOG.md) for what changed between them. Additional vocabulary entries and cross-domain linking examples are still being added.
 
-The AI compatibility isn't coincidental. Large language models process information through patterns and relationships—exactly what this methodology makes explicit. Your knowledge system becomes a thinking partner that both you and AI tools can navigate effectively.
-
-## Learn More
-
-- **Book**: "Networked Thinking" by Jason Gilbertson and Terri Yeh launches in 2026.
-- **Contact**: Email [jason.gilbertson@gmail.com](mailto:jason.gilbertson@gmail.com) or [yeh.terri@gmail.com](mailto:yeh.terri@gmail.com) for early access or questions.
-- **Updates**: [Star this repository](https://github.com/jrgilbertson/networked-thinking) to receive notifications when new features and workflow examples are added.
+Learn more and join the waitlist at [networkedthinking.ai](https://networkedthinking.ai/). For beta reading or early-access questions, email [jason.gilbertson@gmail.com](mailto:jason.gilbertson@gmail.com) or [yeh.terri@gmail.com](mailto:yeh.terri@gmail.com).
 
 ## License
 
-This vault template is released under Creative Commons CC BY 4.0. You're free to use, modify, and share with attribution.
-
----
-
-*Note: This is an active project. Star the repository to be notified when workflow examples and AI integration guides are added.*
+CC BY 4.0. See [LICENSE](LICENSE.md).


### PR DESCRIPTION
The README now reads as the book-launch storefront instead of a pre-branding starter-kit page: the Networked Thinking positioning (book + practical system) leads, sections follow a single-word canon (Quickstart, Purpose, Structure, Status, License), stale references to the deleted `Prompts/` folder are gone, and every factual claim — note, template, and structure-note counts, release count, folder list — was verified against the vault's actual contents before writing. A new `CHANGELOG.md` (Keep a Changelog format) backfills the two tagged releases from their real release history, and Dependabot now watches the `github-actions` ecosystem, the repo's only dependency surface.

Authored with the new `repo-best-practices` skill from the agentic toolkit (its PR is linked below once open). Owner reviewed and approved every file interactively, including the Purpose framing verbatim from the book's positioning copy.

## Validation

Prose passed ai-check plus deterministic anti-slop and vault-structure graders from the skill's eval suite; `GETTING-STARTED.md`'s remaining stale `Prompts/` references are deliberately left for a follow-up (routed to repo-maintainer, outside this pass's surface).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
