### PR TITLE
build(deps): bump actions/checkout to v7.0.0 and claude-code-action to v1.0.169

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,14 +36,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@fad22eb3fa582b7357fc0ea48af6645851b884fd # v1.0.161
+        uses: anthropics/claude-code-action@37b464ce72700f7b2c5ff8d2db7fa7b15df792f5 # v1.0.169
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,14 +26,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@fad22eb3fa582b7357fc0ea48af6645851b884fd # v1.0.161
+        uses: anthropics/claude-code-action@37b464ce72700f7b2c5ff8d2db7fa7b15df792f5 # v1.0.169
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Combines Dependabot PRs #26 and #25. Both touch the same two workflow files, so they're easier to review and land as one change.

| Action | From | To | Type |
|---|---|---|---|
| `actions/checkout` | 6.0.3 | 7.0.0 | major |
| `anthropics/claude-code-action` | 1.0.161 | 1.0.169 | patch |

## Is the major bump safe?

Yes. The only breaking change in [checkout v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0) is [#2454](https://github.com/actions/checkout/pull/2454), which blocks checking out fork PRs under `pull_request_target` and `workflow_run`. Neither workflow uses those triggers:

- `claude-code-review.yml` runs on `pull_request` (`opened`, `ready_for_review`), already guarded by `head.repo.full_name == github.repository`.
- `claude.yml` runs on `issue_comment`, `pull_request_review_comment`, `issues`, and `pull_request_review`.

The rest of v7 is dependency bumps and an ESM module conversion.

## Verification

- Both pinned SHAs dereferenced against their upstream tags and confirmed to match. `claude-code-action`'s `v1.0.169` is an annotated tag, so it required a second deref to reach commit `37b464c`.
- Diff is exactly 4 lines, matching #26 and #25 combined.
- `git diff --check` clean; both workflow files parse as YAML with their jobs intact.

Closes #26. Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZQncw11MKALwEnvymwxHb