### PR TITLE
fix: clarify atomic note title and filename guidance

### DIFF
--- a/Templates/Atomic Note Template.md
+++ b/Templates/Atomic Note Template.md
@@ -8,7 +8,7 @@ title: "{{Title}}"
 
 # {{Title}}
 
-{{Title and filename are the full one-sentence Definition (e.g. "Net revenue retention (NRR) is the percentage of recurring revenue retained…"). Put the short concept name and any acronym in aliases.}}
+{{Title is the short concept name (2–5 words) used in both the YAML title and H1. Name the file with the timestamp followed by the Definition's first sentence without its final period (e.g. "202507151230 Net revenue retention (NRR) is the percentage of recurring revenue retained.md"). Put useful alternative names and acronyms in aliases.}}
 
 TARGET DECK: General
 


### PR DESCRIPTION
## Summary

- Clarify that YAML `title` and H1 share the same short concept name.
- Keep the filename rule separate: timestamp plus the Definition's first sentence without its final period.
- Preserve alternative names and acronyms as aliases.

This updates the canonical companion-vault template used by the Networked Thinking book. It supports [networked-thinking-skills issue #28](https://github.com/jrgilbertson/networked-thinking-skills/issues/28) and is paired with [networked-thinking-skills#29](https://github.com/jrgilbertson/networked-thinking-skills/pull/29).

Session-settled decision carried from planning: the short concept name belongs in YAML `title` and H1, while the full first Definition sentence determines the filename.

## Validation

- `git diff --check origin/main...HEAD`
- Targeted inspection confirmed valid Obsidian frontmatter and Markdown.
- Verified the book repository's companion-vault symlink reflects the canonical template change.
- Independent review found no issues or unrelated edits.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this is a one-line template-guidance change. After merge, maintainers can verify the template renders normally in Obsidian and that newly created notes follow the two naming pairs.

---
[![Compound Engineering](https://img.shields.io/badge/Compound-Engineering-blue)](https://github.com/EveryInc/compound-engineering-plugin)
