### PR TITLE
docs: clarify transient working artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@
 .compound-engineering/*.local.yaml
 
 # This repo ships as a clean Obsidian vault, so agent working folders stay out.
-# Learnings, ideation, and plans live in the skills and site repos instead.
+# Promote durable material into the repository and path that owns it.
 docs/
 .impeccable/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repository is an Obsidian vault template for the Networked Thinking methodo
 
 Start with `README.md` and `GETTING-STARTED.md` when you need product context. Use the existing notes and files under `Templates/` as the source of truth for local note structure.
 
-This repository ships as a clean Obsidian vault, so it keeps no `docs/` tree. Everything tracked here is content a downloader opens in Obsidian. `.gitignore` already keeps a stray `docs/` tree out of commits, so leave one a tool writes rather than deleting untracked work. The same goes for working documents at the root: durable learnings, ideation studies, plans, and product or design briefs live in `networked-thinking-skills` or `networked-thinking-site`, which are not vaults.
+This repository ships as a clean Obsidian vault, so it keeps no `docs/` tree. Everything tracked here is content a downloader opens in Obsidian. `.gitignore` keeps a tool-created `docs/` tree out of commits, so leave that untracked work in place. Plans, ideation, raw research, and generated reports are temporary worktree material here and in sibling repositories. Promote only durable learnings or current product and design guidance into the repository that owns them.
 
 ## Editing Rules
 


### PR DESCRIPTION
## Summary

The vault guidance now treats plans, ideation, raw research, and generated reports as temporary worktree material. Durable learnings and current product or design guidance move to the repository that owns them.

This is one repository in the cross-repository transient-artifact cleanup. The vault already ignored its entire `docs/` tree, so no content migration was needed.

## Validation

- Repository hooks passed during commit.
- Exact path, text, and whitespace checks passed.
